### PR TITLE
The async ssh list drops every other server

### DIFF
--- a/contrib/bin/user-ssh-list-async
+++ b/contrib/bin/user-ssh-list-async
@@ -69,22 +69,21 @@ def main():
     children = []
 
     for server in servers:
-        if len(children) < max_processes:
-            pid = os.fork()
-            if pid:
-                children.append(pid)
-            else:
-                try:
-                    status = 1
-                    run_command_on(server, args.command, args.username)
-                    status = 0
-                finally:
-                    # normally done at process exit, but we have to use os._exit when forking
-                    # so we gotta do our cleanup ourselves
-                    sys.stdout.flush()
-                    sys.stderr.flush()
-                    os._exit(status)
+        pid = os.fork()
+        if pid:
+            children.append(pid)
         else:
+            try:
+                status = 1
+                run_command_on(server, args.command, args.username)
+                status = 0
+            finally:
+                # normally done at process exit, but we have to use os._exit when forking
+                # so we gotta do our cleanup ourselves
+                sys.stdout.flush()
+                sys.stderr.flush()
+                os._exit(status)
+        if len(children) >= max_processes:
             dead_child, status = os.wait()
             children.remove(dead_child)
 


### PR DESCRIPTION
The logic drops one server entry each time the pool size limit is
hit. This means the logic has only been executing on every other
server beyond the first SSH_LIST_POOL_SIZE all this time.