### PR TITLE
add servernum keyword to clusto-query

### DIFF
--- a/clusto_query/context.py
+++ b/clusto_query/context.py
@@ -1,4 +1,5 @@
 import collections
+import itertools
 
 from . import clusto_types
 
@@ -101,3 +102,13 @@ class Context(object):
             if maybe_attrs and maybe_attrs[0].value == 'role':
                 return pool.name
         return None
+
+    def servernum_for_host(self, host):
+        """Expect that hostnames look like (?P<role>\D+)(?P<servernum>\d+).*, extract the servernum"""
+        if not isinstance(host, ContextKey):
+            host = _generate_key(host)
+        host = self.entity_map[host]
+        for isnum, chars in itertools.groupby(host.name, lambda x: x.isdigit()):
+            if isnum:
+                return int(''.join(chars))
+        return 0

--- a/clusto_query/lexer.py
+++ b/clusto_query/lexer.py
@@ -7,7 +7,7 @@ from clusto_query import clusto_types
 
 
 SEARCH_KEYWORDS = list(clusto_types.CONTEXT_TYPES)[:]
-SEARCH_KEYWORDS.extend(["name", "hostname", "role", "clusto_type"])
+SEARCH_KEYWORDS.extend(["name", "hostname", "role", "clusto_type", "servernum"])
 
 _single_quoted_string_re = re.compile(r"'(((\\')|[^'])*)'")
 _double_quoted_string_re = re.compile(r'"(((\\")|[^"])*)"')


### PR DESCRIPTION
Allows you to run queries like

```
% clusto-query "pool = app and servernum < 10"
```

to get the first 10 app hosts

It'd be fun to do real type inference here instead of just assuming that they type returned by the lhs is always accurate.
