### PR TITLE
allow using "exists" with direct attributes

### DIFF
--- a/clusto_query/query/operator/affix.py
+++ b/clusto_query/query/operator/affix.py
@@ -49,8 +49,11 @@ class ExistsOperator(SuffixOperator):
     operator = ('exists',)
 
     def _exists(self, host, context):
-        prop = _extract_property(host, self.lhs, context)
-        return bool(prop)
+        try:
+            prop = _extract_property(host, self.lhs, context)
+            return bool(prop)
+        except AttributeError:
+            return False
 
     def run(self, candidate_hosts, context):
         hosts = set()


### PR DESCRIPTION
Allows you to do a query like

```
clusto-query public_ip exists
```

to show all items with a public IP
