### PR TITLE
Fix order

### DIFF
--- a/clusto_query/__init__.py
+++ b/clusto_query/__init__.py
@@ -1,3 +1,3 @@
-version_info = (0, 5, 2)
+version_info = (0, 5, 3)
 __version__ = '.'.join(str(s) for s in version_info)
 __author__ = 'James Brown <jbrown@uber.com>'

--- a/clusto_query/clusto_types.py
+++ b/clusto_query/clusto_types.py
@@ -1,16 +1,17 @@
 import clusto
 
-# all types known to clusto
-CLUSTO_TYPES = set(clusto.TYPELIST.keys()) - set(['clustometa'])
+def get_context_types():
+    # all types known to clusto
+    CLUSTO_TYPES = set(clusto.TYPELIST.keys()) - set(['clustometa'])
 
-# types which should be recursively searched to build parent/child relationships
-CONTEXT_TYPES = set(
-    k
-    for k in CLUSTO_TYPES
-    if (
-        'server' not in k and
-        k != 'generic' and
-        k != 'appliance' and
-        k != 'resourcemanger'
+    # types which should be recursively searched to build parent/child relationships
+    return set(
+        k
+        for k in CLUSTO_TYPES
+        if (
+            'server' not in k and
+            k != 'generic' and
+            k != 'appliance' and
+            k != 'resourcemanger'
+        )
     )
-)

--- a/clusto_query/context.py
+++ b/clusto_query/context.py
@@ -17,14 +17,13 @@ def _generate_key(clusto_item):
 
 
 class Context(object):
-    """ Context for a clusto query. """
-    CONTEXT_TYPES = clusto_types.CONTEXT_TYPES
 
     def __init__(self, clusto_proxy):
         self.clusto_proxy = clusto_proxy
         self.entity_map = dict((_generate_key(e), e)
                                for e in clusto_proxy.get_entities())
         self.context_dict = None
+        self.context_types = clusto_types.get_context_types()
 
     @staticmethod
     def str_type(clusto_object):
@@ -47,7 +46,7 @@ class Context(object):
         # yay.
         relationships = adjacency_map()
         for row in relationships:
-            if row.parent_type not in self.CONTEXT_TYPES:
+            if row.parent_type not in self.context_types:
                 continue
             root_name = ContextKey(row.parent_type, row.parent_name)
             child_name = ContextKey(row.child_type, row.child_name)
@@ -74,7 +73,7 @@ class Context(object):
         results = dict(
             (typ, collections.defaultdict(set))
             for typ
-            in self.CONTEXT_TYPES
+            in self.context_types
         )
 
         # finally, reverse it
@@ -87,7 +86,7 @@ class Context(object):
     def context(self, typ, host):
         if self.context_dict is None:
             self.populate_pools_and_datacenters()
-        if typ in self.CONTEXT_TYPES:
+        if typ in self.context_types:
             return self.context_dict[typ].get(host, set([]))
         else:
             raise AttributeError()

--- a/clusto_query/lexer.py
+++ b/clusto_query/lexer.py
@@ -6,13 +6,16 @@ from clusto_query.query.operator import (BOOLEAN_OPERATORS,
 from clusto_query import clusto_types
 
 
-SEARCH_KEYWORDS = list(clusto_types.CONTEXT_TYPES)[:]
-SEARCH_KEYWORDS.extend(["name", "hostname", "role", "clusto_type"])
-
 _single_quoted_string_re = re.compile(r"'(((\\')|[^'])*)'")
 _double_quoted_string_re = re.compile(r'"(((\\")|[^"])*)"')
 _unquoted_string_re = re.compile(r'([\w./:-]+)')
 _separator_re = re.compile(r'[^a-zA-Z0-9_-]|\Z')
+
+
+def get_search_keywords():
+    keywords = list(clusto_types.get_context_types())[:]
+    keywords.extend(["name", "hostname", "role", "clusto_type"])
+    return keywords
 
 
 def consume(token, string):
@@ -70,7 +73,7 @@ def lex_string(string):
 
 def lex(q):
     keywords = ["attr"]
-    keywords.extend(SEARCH_KEYWORDS)
+    keywords.extend(get_search_keywords())
     keywords.extend(BOOLEAN_OPERATORS.keys())
     keywords.extend(UNARY_BOOLEAN_OPERATORS.keys())
     keywords.extend(INFIX_OPERATORS.keys())

--- a/clusto_query/query/operator/affix.py
+++ b/clusto_query/query/operator/affix.py
@@ -31,7 +31,7 @@ def _extract_property(host, attribute, context):
         return context.entity_map[host]._clusto_type
     elif attribute == "role":
         return context.role_for_host(host)
-    elif attribute in context.CONTEXT_TYPES:
+    elif attribute in context.context_types:
         return map(_extract_name_from_key, context.context(attribute, host))
     else:
         return getattr(context.entity_map[host], attribute)

--- a/clusto_query/scripts/main.py
+++ b/clusto_query/scripts/main.py
@@ -16,7 +16,7 @@ import clusto.script_helper
 
 
 from clusto_query.query.objects import RFC1918
-from clusto_query.lexer import lex, SEARCH_KEYWORDS
+from clusto_query.lexer import lex, get_search_keywords
 from clusto_query.parser import parse_query
 from clusto_query import settings
 from clusto_query.context import Context
@@ -47,9 +47,6 @@ Infix expression operators are the following:
 
 Additionally, there are boolean operators and, or, and - (set subtraction)
 
-The following keywords can be directly queried:
-%(search_keywords)s
-
 Anything that's an "Attribute" must be prefixed with attr.
 
 Here's an example query:
@@ -74,7 +71,6 @@ Quoting and parens work the way you expect them to.
 """ % {
     'version': __version__,
     'author': __author__,
-    'search_keywords': '\n'.join('- %s' % kw for kw in sorted(SEARCH_KEYWORDS))
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='clusto_query',
-      version='0.5.2',
+      version='0.5.3',
       author='James Brown',
       author_email='jbrown@uber.com',
       description='Perform arbitrary boolean queries against clusto',


### PR DESCRIPTION
CONTEXT_TYPES can only be correctly calculated after plugin is loaded, otherwise all types from plugin will be missing and query like "datacenter = sjc1 and pool = app" would return empty result.