### PR TITLE
Return empty value string as is.

### DIFF
--- a/clusto_query/__init__.py
+++ b/clusto_query/__init__.py
@@ -1,3 +1,3 @@
-version_info = (0, 5, 2)
+version_info = (0, 5, 3)
 __version__ = '.'.join(str(s) for s in version_info)
 __author__ = 'James Brown <jbrown@uber.com>'

--- a/clusto_query/query/objects.py
+++ b/clusto_query/query/objects.py
@@ -78,6 +78,8 @@ class Attribute(QueryObject):
             return value.name
         elif not isinstance(value, basestring):
             return value
+        elif not value:
+            return value
         elif all(c.isdigit() for c in value):
             return int(value)
         elif all(c.isdigit() or c == "." for c in value):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='clusto_query',
-      version='0.5.2',
+      version='0.5.3',
       author='James Brown',
       author_email='jbrown@uber.com',
       description='Perform arbitrary boolean queries against clusto',


### PR DESCRIPTION
This should fix the case that an empty string as attribute value will error out the query, even if it's not on the result object supposed to be returned.

Also bumps version.